### PR TITLE
Feature: Post Item Linking

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,11 +4,12 @@
  * See: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/
  */
 
-const path = require('path');
+const path = require('path')
+const { createFilePath } = require(`gatsby-source-filesystem`)
 
 //Setup Import Alias
 exports.onCreateWebpackConfig = ({ getConfig, actions }) => {
-  const output = getConfig().output || {};
+  const output = getConfig().output || {}
 
   actions.setWebpackConfig({
     output,
@@ -16,8 +17,19 @@ exports.onCreateWebpackConfig = ({ getConfig, actions }) => {
       alias: {
         components: path.resolve(__dirname, 'src/components'),
         utils: path.resolve(__dirname, 'src/utils'),
-        hooks: path.resolve(__dirname, 'src/hooks')
+        hooks: path.resolve(__dirname, 'src/hooks'),
       },
     },
-  });
-};
+  })
+}
+
+// Generate a Slug Each Post Data
+exports.onCreateNode = ({ node, getNode, actions }) => {
+  const { createNodeField } = actions
+
+  if (node.internal.type === `MarkdownRemark`) {
+    const slug = createFilePath({ node, getNode })
+
+    createNodeField({ node, name: 'slug', value: slug })
+  }
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -33,3 +33,61 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
     createNodeField({ node, name: 'slug', value: slug })
   }
 }
+
+// Generate Post Page through Markdown Data
+exports.createPages = async ({ actions, graphql, reporter }) => {
+  const { createPage } = actions
+
+  // Get All Markdown File for Paging
+  const queryAllMarkdownData = await graphql(
+    `
+      {
+        allMarkdownRemark(
+          sort: {
+            order: DESC
+            fields: [frontmatter___date, frontmatter___title]
+          }
+        ) {
+          edges {
+            node {
+              fields {
+                slug
+              }
+            }
+          }
+        }
+      }
+    `,
+  )
+
+  // Handling GraphQL Query Error
+  if (queryAllMarkdownData.errors) {
+    reporter.panicOnBuild(`Error while running query`)
+
+    return
+  }
+
+  // Import Post Template Component
+  const PostTemplateComponent = path.resolve(
+    __dirname,
+    'src/templates/post_template.tsx',
+  )
+
+  // Page Generating Function
+  const generatePostPage = ({
+    node: {
+      fields: { slug },
+    },
+  }) => {
+    const pageOptions = {
+      path: slug,
+      component: PostTemplateComponent,
+      context: { slug },
+    }
+
+    createPage(pageOptions)
+  }
+
+  //Generate Post Page and Passing Slug Props for Query
+  queryAllMarkdownData.data.allMarkdownRemark.edges.forEach(generatePostPage)
+}

--- a/src/components/main/PostList.tsx
+++ b/src/components/main/PostList.tsx
@@ -49,13 +49,17 @@ const PostList: FunctionComponent<PostListProps> = function ({
 
   return (
     <PostListWrapper ref={containerRef}>
-      {postList.map(({ node: { id, frontmatter } }: PostListItemType) => (
-        <PostItem
-          {...frontmatter}
-          link="https://github.com/Dcom-KHU/dcom-tech-interview/blob/master/Frontend/Android/mvvm-design-pattern.md"
-          key={id}
-        />
-      ))}
+      {postList.map(
+        ({
+          node: {
+            id,
+            fields: { slug },
+            frontmatter,
+          },
+        }: PostListItemType) => (
+          <PostItem {...frontmatter} link={slug} key={id} />
+        ),
+      )}
     </PostListWrapper>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -104,6 +104,9 @@ export const getPostList = graphql`
       edges {
         node {
           id
+          fields {
+            slug
+          }
           frontmatter {
             title
             summary

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -1,0 +1,11 @@
+import React, { FunctionComponent } from 'react'
+
+type PostTemplateProps = {}
+
+const PostTemplate: FunctionComponent<PostTemplateProps> = function (props) {
+  console.log(props)
+
+  return <div>Post Template</div>
+}
+
+export default PostTemplate

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import { graphql } from 'gatsby'
 
 type PostTemplateProps = {}
 
@@ -9,3 +10,26 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function (props) {
 }
 
 export default PostTemplate
+
+export const queryMarkdownDataBySlug = graphql`
+  query queryMarkdownDataBySlug($slug: String) {
+    allMarkdownRemark(filter: { fields: { slug: { eq: $slug } } }) {
+      edges {
+        node {
+          html
+          frontmatter {
+            title
+            summary
+            date(formatString: "YYYY.MM.DD")
+            categories
+            thumbnail {
+              childImageSharp {
+                gatsbyImageData
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/types/PostItem.types.ts
+++ b/src/types/PostItem.types.ts
@@ -15,6 +15,9 @@ export type PostFrontmatterType = {
 export type PostListItemType = {
   node: {
     id: string
+    fields: {
+      slug: string
+    }
     frontmatter: PostFrontmatterType
   }
 }


### PR DESCRIPTION
## 구현한 기능
- Markdown 데이터에 Slug Field 추가
- Slug Data로 Post Item 링크 연결
- 게시글 페이지 Template 생성(`src/templates/post_template.tsx`)


## 사용한 라이브러리 및 API
- Gatsby **`createPages`** API에서 제공하는 createPage 함수.
- Gatsby **`onCreateNode`** API 
  -> 특정 노드에 Field를 추가하는 등의 기능을 구현 가능하게 함.

## 핵심 Code
**`gatsby-node.js`**
```javascript

// Generate a Slug Each Post Data
exports.onCreateNode = ({ node, getNode, actions }) => {
  const { createNodeField } = actions

  if (node.internal.type === `MarkdownRemark`) {
    const slug = createFilePath({ node, getNode })

    createNodeField({ node, name: 'slug', value: slug })
  }
}

// Generate Post Page through Markdown Data
exports.createPages = async ({ actions, graphql, reporter }) => {
  const { createPage } = actions

  // Get All Markdown File for Paging
  const queryAllMarkdownData = await graphql(
    `
      {
        allMarkdownRemark(
          sort: {
            order: DESC
            fields: [frontmatter___date, frontmatter___title]
          }
        ) {
          edges {
            node {
              fields {
                slug
              }
            }
          }
        }
      }
    `,
  )

  // Handling GraphQL Query Error
  if (queryAllMarkdownData.errors) {
    reporter.panicOnBuild(`Error while running query`)

    return
  }

  // Import Post Template Component
  const PostTemplateComponent = path.resolve(
    __dirname,
    'src/templates/post_template.tsx',
  )

  // Page Generating Function
  const generatePostPage = ({
    node: {
      fields: { slug },
    },
  }) => {
    const pageOptions = {
      path: slug,
      component: PostTemplateComponent,
      context: { slug },
    }

    createPage(pageOptions)
  }

  //Generate Post Page and Passing Slug Props for Query
  queryAllMarkdownData.data.allMarkdownRemark.edges.forEach(generatePostPage)
}
```

## 개선할 점
- 게시글 페이지 구현